### PR TITLE
Broadcast CLOSE_SYSTEM_DIALOG intent in the travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
+  - adb shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS
   - adb shell input keyevent 82 &
   - adb shell settings put global window_animation_scale 0
   - adb shell settings put global transition_animation_scale 0


### PR DESCRIPTION
Should fix the `Waited for root` error.